### PR TITLE
Add automatic relation of SO line and logisitc route

### DIFF
--- a/logistic_order/__openerp__.py
+++ b/logistic_order/__openerp__.py
@@ -50,6 +50,7 @@ Contributors
 
 """,
  "depends": ["sale_stock",
+             "stock_dropshipping",
              "sale_validity",
              "delivery",
              "sale_quotation_sourcing",

--- a/logistic_order/model/sale_order.py
+++ b/logistic_order/model/sale_order.py
@@ -42,8 +42,6 @@ class SaleOrderLine(models.Model):
 
         :param purchase_order_line: record of `purchase.order.line` Model
         :type purchase_order_line: :py:class:`openerp.models.Model`
-        purchase_order = purchase_order_line.order_id
-
         :return: PO location usage
         :rtype: str
 

--- a/logistic_order/model/sale_order.py
+++ b/logistic_order/model/sale_order.py
@@ -17,7 +17,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from openerp import models, fields
+from openerp import models, fields, api
 
 
 class SaleOrder(models.Model):
@@ -30,3 +30,66 @@ class SaleOrder(models.Model):
              "predefined commercial terms used in "
              "international transactions.")
     delivery_time = fields.Char('Delivery time')
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.model
+    def _get_po_location_usage(self, purchase_order_line):
+        """Retrieve the destination location usage of a PO
+        from a PO line
+
+        :param purchase_order_line: record of `purchase.order.line` Model
+        :type purchase_order_line: :py:class:`openerp.models.Model`
+        purchase_order = purchase_order_line.order_id
+
+        :return: PO location usage
+        :rtype: str
+
+        """
+        return purchase_order_line.order_id.location_id.usage
+
+    @api.model
+    def _route_from_usage(self, usage):
+        """Return the routes to assing on SO lines
+        based on a location usage.
+
+        If nothing no match return None
+
+        :param usage: stock.location Model usage
+        :type usage: str
+
+        :return: a record of `stock.location.route`
+        :rtype: :py:class:`openerp.models.Model` or None
+        """
+        if usage == 'customer':
+            return self.env.ref('stock_dropshipping.route_drop_shipping')
+        elif usage == 'internal':
+            return self.env.ref('stock.route_warehouse0_mto')
+        else:
+            return None
+
+    @api.one
+    @api.onchange('sourced_by')
+    @api.constrains('sourced_by')
+    def set_route_form_so(self):
+        """Set route on SO line based on fields sourced_by.
+
+        Wee look for the PO related
+        to current SO line by the sourced_by fields.
+
+        If the PO has a destination location with usage
+        "customer" we apply the dropshipping route to current SO line.
+
+        If the PO has a destination location with usage
+        "internal" we apply the make to order route to current SO line.
+
+        As there is no trigger decorator that works on
+        non computed fields we use constrains decorator instead.
+        """
+        if not self.sourced_by:
+            return
+        usage = self._get_po_location_usage(self.sourced_by)
+        route = self._route_from_usage(usage)
+        self.route_id = route

--- a/logistic_order/model/sale_order.py
+++ b/logistic_order/model/sale_order.py
@@ -49,7 +49,7 @@ class SaleOrderLine(models.Model):
         return purchase_order_line.order_id.location_id.usage
 
     @api.model
-    def _route_from_usage(self, usage):
+    def _find_route_from_usage(self, usage):
         """Return the routes to assing on SO lines
         based on a location usage.
 
@@ -89,5 +89,6 @@ class SaleOrderLine(models.Model):
         if not self.sourced_by:
             return
         usage = self._get_po_location_usage(self.sourced_by)
-        route = self._route_from_usage(usage)
-        self.route_id = route
+        route = self._find_route_from_usage(usage)
+        if route:
+            self.route_id = route

--- a/logistic_order/tests/__init__.py
+++ b/logistic_order/tests/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Nicolas Bessi
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import test_sourced_by

--- a/logistic_order/tests/test_sourced_by.py
+++ b/logistic_order/tests/test_sourced_by.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Nicolas Bessi
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+import openerp.tests.common as test_common
+
+
+class TestSourcedBy(test_common.TransactionCase):
+
+    def test_get_route_from_usage(self):
+        so_line_model = self.env['sale.order.line']
+        ds_route = self.env.ref('stock_dropshipping.route_drop_shipping')
+        mto_route = self.env.ref('stock.route_warehouse0_mto')
+        self.assertTrue(ds_route)
+        self.assertTrue(mto_route)
+        self.assertEqual(
+            so_line_model._find_route_from_usage('customer'),
+            ds_route
+        )
+        self.assertEquals(
+            so_line_model._find_route_from_usage('internal'),
+            mto_route
+        )
+        self.assertEquals(
+            so_line_model._find_route_from_usage('supplier'),
+            None
+        )
+
+    def test_get_po_usage(self):
+        so_line_model = self.env['sale.order.line']
+        po_line = self.env.ref('purchase.purchase_order_2').order_line[0]
+        usage = so_line_model._get_po_location_usage(po_line)
+        self.assertEqual(usage, 'internal')


### PR DESCRIPTION
based on sourced_by field.

 Wee look for the PO related to current SO line by the sourced_by fields.

 If the PO has a destination location with usage "customer" we apply the dropshipping route to  SO line.

 If the PO has a destination location with usage "internal" we apply the make to order route to  SO line.
