### PR TITLE
fix: don't set code on PO generated from agreement

### DIFF
--- a/framework_agreement_sourcing/model/logistic_requisition_source.py
+++ b/framework_agreement_sourcing/model/logistic_requisition_source.py
@@ -86,7 +86,6 @@ class logistic_requisition_source(orm.Model):
         data['fiscal_position'] = position
         data['origin'] = requisition.name
         data['date_order'] = requisition.date
-        data['name'] = requisition.name
         data['consignee_id'] = requisition.consignee_id.id
         data['incoterm_id'] = requisition.incoterm_id.id
         data['incoterm_address'] = requisition.incoterm_address

--- a/framework_agreement_sourcing/tests/test_agreement_souce_line_to_po.py
+++ b/framework_agreement_sourcing/tests/test_agreement_souce_line_to_po.py
@@ -78,7 +78,7 @@ class TestSourceToPo(CommonSourcingSetUp):
         self.assertEqual(po.dest_address_id, add)
         self.assertEqual(po.consignee_id, consignee)
         self.assertEqual(po.state, 'draftpo')
-
+        self.assertNotEqual(po.name, self.requisition.name)
         self.assertEqual(len(po.order_line), 2)
 
         po_line = next(x for x in po.order_line


### PR DESCRIPTION
When generating a purchase order from a framework agreement, the code
should be auto-generated from the sequence, and not be equal to the code
of the logistic requisition.

This bug was already fixed on v7 by Nicolas Bessi. Then for some reason,
while porting to v8 I re-enabled a commented out line bringing that
back.

Now it is deleted for good.
