### PR TITLE
improve feedback when lines are not sourced

### DIFF
--- a/framework_agreement_sourcing/model/logistic_requisition_source.py
+++ b/framework_agreement_sourcing/model/logistic_requisition_source.py
@@ -263,6 +263,8 @@ class logistic_requisition_source(orm.Model):
         if tender_errors and agr_errors:
             return ['{0}: Sourcing errors both on Agreement mode  '
                     'and in Procurement mode.'.format(self.name)]
+        else:
+            return []
 
     @api.multi
     def _check_sourcing_fw_agreement(self):

--- a/framework_agreement_sourcing/model/logistic_requisition_source.py
+++ b/framework_agreement_sourcing/model/logistic_requisition_source.py
@@ -238,15 +238,6 @@ class logistic_requisition_source(orm.Model):
             cr, uid, main_source, other_sources, pricelist, context=None)
         return po_id
 
-    def _is_sourced_other(self, cr, uid, source, context=None):
-        """Predicate function to test if line on other
-        method are sourced"""
-        tender_ok = self._is_sourced_procurement(cr, uid, source,
-                                                 context=context)
-        agr_ok = self._is_sourced_fw_agreement(cr, uid, source,
-                                               context=context)
-        return (tender_ok or agr_ok)
-
     def _get_purchase_order_lines(self):
         """Convenience method to return the purchase order lines associated
         with the lr_source_line_id.
@@ -260,6 +251,18 @@ class logistic_requisition_source(orm.Model):
             ('lr_source_line_id', '=', self.id)
         ])
 
+    @api.multi
+    def _check_sourcing_other(self):
+        """Check sourcing for "other" mode.
+
+        :returns: list of error strings
+
+        """
+        tender_errors = self._check_sourcing_procurement()
+        agr_errors = self._check_sourcing_fw_agreement()
+        if tender_errors and agr_errors:
+            return ['{0}: Sourcing errors both on Agreement mode  '
+                    'and in Procurement mode.'.format(self.name)]
 
     @api.multi
     def _check_sourcing_fw_agreement(self):

--- a/framework_agreement_sourcing/tests/__init__.py
+++ b/framework_agreement_sourcing/tests/__init__.py
@@ -17,3 +17,4 @@
 from . import common
 from . import test_logistic_order_line_to_source_line
 from . import test_agreement_souce_line_to_po
+from . import test_check_sourcing

--- a/framework_agreement_sourcing/tests/__init__.py
+++ b/framework_agreement_sourcing/tests/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Author: Nicolas Bessi
-#    Copyright 2013 Camptocamp SA
+#    Author: Nicolas Bessi, Leonardo Pistone
+#    Copyright 2013, 2014 Camptocamp SA
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -16,10 +14,6 @@
 #
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
 from . import common
 from . import test_logistic_order_line_to_source_line
 from . import test_agreement_souce_line_to_po
-checks = [test_logistic_order_line_to_source_line,
-          test_agreement_souce_line_to_po]

--- a/framework_agreement_sourcing/tests/test_check_sourcing.py
+++ b/framework_agreement_sourcing/tests/test_check_sourcing.py
@@ -1,0 +1,43 @@
+#    Author: Leonardo Pistone
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from openerp.tests.common import TransactionCase
+
+
+class TestCheckSourcing(TransactionCase):
+    """Check the _check_sourcing method of the source. """
+
+    def test_agreement_sourcing_without_po_is_not_sourced(self):
+        self.source.procurement_method = 'fw_agreement'
+        errors = self.source._check_sourcing()
+        self.assertEquals(1, len(errors))
+        self.assertIn('Missing Purchase Order', errors[0])
+
+    def test_agreement_sourcing_with_po_is_sourced(self):
+        self.source.procurement_method = 'fw_agreement'
+        self.source.framework_agreement_po_id = self.PO.new()
+        self.assertEquals([], self.source._check_sourcing())
+
+    def setUp(self):
+        """Setup a source.
+
+        I use Model.new to get a model instance that is not saved to the
+        database, but has working methods.
+
+        """
+        super(TestCheckSourcing, self).setUp()
+        Source = self.env['logistic.requisition.source']
+        self.PO = self.env['purchase.order']
+        self.source = Source.new()

--- a/framework_agreement_sourcing/tests/test_check_sourcing.py
+++ b/framework_agreement_sourcing/tests/test_check_sourcing.py
@@ -30,6 +30,12 @@ class TestCheckSourcing(TransactionCase):
         self.source._get_purchase_order_lines = lambda: self.PO.new()
         self.assertEquals([], self.source._check_sourcing())
 
+    def test_other_sourcing_without_pr_nor_pol_is_not_sourced(self):
+        self.source.procurement_method = 'other'
+        errors = self.source._check_sourcing()
+        self.assertEquals(1, len(errors))
+        self.assertIn('Sourcing errors', errors[0])
+
     def setUp(self):
         """Setup a source.
 

--- a/framework_agreement_sourcing/tests/test_check_sourcing.py
+++ b/framework_agreement_sourcing/tests/test_check_sourcing.py
@@ -41,6 +41,17 @@ class TestCheckSourcing(TransactionCase):
         self.source.po_requisition_id = self.PurcReq.new({'state': 'closed'})
         self.assertEquals([], self.source._check_sourcing())
 
+    def test_other_sourcing_without_pr_with_pol_is_sourced(self):
+        self.source.procurement_method = 'other'
+        self.source._get_purchase_order_lines = lambda: self.PO.new()
+        self.assertEquals([], self.source._check_sourcing())
+
+    def test_other_sourcing_with_pr_and_pol_is_sourced(self):
+        self.source.procurement_method = 'other'
+        self.source.po_requisition_id = self.PurcReq.new({'state': 'closed'})
+        self.source._get_purchase_order_lines = lambda: self.PO.new()
+        self.assertEquals([], self.source._check_sourcing())
+
     def setUp(self):
         """Setup a source.
 

--- a/framework_agreement_sourcing/tests/test_check_sourcing.py
+++ b/framework_agreement_sourcing/tests/test_check_sourcing.py
@@ -36,6 +36,11 @@ class TestCheckSourcing(TransactionCase):
         self.assertEquals(1, len(errors))
         self.assertIn('Sourcing errors', errors[0])
 
+    def test_other_sourcing_with_pr_without_pol_is_sourced(self):
+        self.source.procurement_method = 'other'
+        self.source.po_requisition_id = self.PurcReq.new({'state': 'closed'})
+        self.assertEquals([], self.source._check_sourcing())
+
     def setUp(self):
         """Setup a source.
 
@@ -46,4 +51,5 @@ class TestCheckSourcing(TransactionCase):
         super(TestCheckSourcing, self).setUp()
         Source = self.env['logistic.requisition.source']
         self.PO = self.env['purchase.order']
+        self.PurcReq = self.env['purchase.requisition']
         self.source = Source.new()

--- a/framework_agreement_sourcing/tests/test_check_sourcing.py
+++ b/framework_agreement_sourcing/tests/test_check_sourcing.py
@@ -23,11 +23,11 @@ class TestCheckSourcing(TransactionCase):
         self.source.procurement_method = 'fw_agreement'
         errors = self.source._check_sourcing()
         self.assertEquals(1, len(errors))
-        self.assertIn('Missing Purchase Order', errors[0])
+        self.assertIn('No Purchase Order Lines', errors[0])
 
     def test_agreement_sourcing_with_po_is_sourced(self):
         self.source.procurement_method = 'fw_agreement'
-        self.source.framework_agreement_po_id = self.PO.new()
+        self.source._get_purchase_order_lines = lambda: self.PO.new()
         self.assertEquals([], self.source._check_sourcing())
 
     def setUp(self):

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -497,7 +497,7 @@ class LogisticsRequisitionLine(models.Model):
         if errors:
             raise except_orm(
                 _('Incorrect Sourcing'),
-                _('XXXXX')
+                _('\n'.join(errors))
             )
         self.state = 'sourced'
 

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -877,28 +877,28 @@ class LogisticsRequisitionSource(models.Model):
          ['po_requisition_id', 'requisition_id']),
     ]
 
-    @api.model
-    def _is_sourced_procurement(self, source):
+    @api.multi
+    def _is_sourced_procurement(self):
         """Predicate function to test if line on procurement
         method are sourced"""
-        if (not source.po_requisition_id or
-                source.po_requisition_id.state not in ['done', 'closed']):
+        if (not self.po_requisition_id or
+                self.po_requisition_id.state not in ['done', 'closed']):
             return False
         return True
 
-    @api.model
-    def _is_sourced_other(self, source):
+    @api.multi
+    def _is_sourced_other(self):
         """Predicate function to test if line on other
         method are sourced"""
-        return True
+        return self._is_sourced_procurement()
 
-    @api.model
-    def _is_sourced_wh_dispatch(self, source):
+    @api.multi
+    def _is_sourced_wh_dispatch(self):
         """Predicate function to test if line on warehouse
         method are sourced"""
         return True
 
-    @api.model
+    @api.multi
     def _is_sourced(self):
         """ check if line is source using predicate function
         that must be called _is_sourced_ + name of procurement.
@@ -907,8 +907,7 @@ class LogisticsRequisitionSource(models.Model):
         callable_name = "_is_sourced_%s" % self.procurement_method
         if not hasattr(self, callable_name):
             raise NotImplementedError(callable_name)
-        callable_fun = getattr(self, callable_name)
-        return callable_fun(self)
+        return getattr(self, callable_name)()
 
     @api.multi
     def _check_purchase_requisition_unique(self):

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -492,6 +492,8 @@ class LogisticsRequisitionLine(models.Model):
     @api.one
     def _do_sourced(self):
         errors = []
+        if not self.source_ids:
+            raise Warning(_('Incorrect Sourcing'), _('No Sourcing Lines'))
         for source in self.source_ids:
             errors += source._check_sourcing()
         if errors:

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -905,8 +905,6 @@ class LogisticsRequisitionSource(models.Model):
         :returns: boolean True if sourced"""
         self.ensure_one()
         callable_name = "_is_sourced_%s" % self.procurement_method
-        if not hasattr(self, callable_name):
-            raise NotImplementedError(callable_name)
         return getattr(self, callable_name)()
 
     @api.multi

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -886,7 +886,7 @@ class LogisticsRequisitionSource(models.Model):
         """
         if (not self.po_requisition_id or
                 self.po_requisition_id.state not in ['done', 'closed']):
-            return False
+            return ['Purchase Requisition error']
         return []
 
     @api.multi

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -884,9 +884,11 @@ class LogisticsRequisitionSource(models.Model):
         :returns: list of error strings
 
         """
-        if (not self.po_requisition_id or
-                self.po_requisition_id.state not in ['done', 'closed']):
-            return ['Purchase Requisition error']
+        if not self.po_requisition_id:
+            return ['Missing Purchase Requisition']
+        if self.po_requisition_id.state not in ['done', 'closed']:
+            return ['Purchase Requisition state should be '
+                    '"Bids Selected" or "PO Created"']
         return []
 
     @api.multi

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -878,33 +878,46 @@ class LogisticsRequisitionSource(models.Model):
     ]
 
     @api.multi
-    def _is_sourced_procurement(self):
-        """Predicate function to test if line on procurement
-        method are sourced"""
+    def _check_sourcing_procurement(self):
+        """Check sourcing for "procurement" method.
+
+        :returns: list of error strings
+
+        """
         if (not self.po_requisition_id or
                 self.po_requisition_id.state not in ['done', 'closed']):
             return False
-        return True
+        return []
 
     @api.multi
-    def _is_sourced_other(self):
-        """Predicate function to test if line on other
-        method are sourced"""
+    def _check_sourcing_other(self):
+        """Check sourcing for "other" method.
+
+        :returns: list of error strings
+
+        """
         return self._is_sourced_procurement()
 
     @api.multi
-    def _is_sourced_wh_dispatch(self):
-        """Predicate function to test if line on warehouse
-        method are sourced"""
-        return True
+    def _check_sourcing_wh_dispatch(self):
+        """Check sourcing for "warehouse dispatch" method.
+
+        :returns: list of error strings
+
+        """
+        return []
 
     @api.multi
-    def _is_sourced(self):
-        """ check if line is source using predicate function
-        that must be called _is_sourced_ + name of procurement.
-        :returns: boolean True if sourced"""
+    def _check_sourcing(self):
+        """Check sourcing for all methods.
+
+        Delegates to methods _check_sourcing_ + procurement_method.
+
+        :returns: list of error strings
+
+        """
         self.ensure_one()
-        callable_name = "_is_sourced_%s" % self.procurement_method
+        callable_name = "_check_sourcing_%s" % self.procurement_method
         return getattr(self, callable_name)()
 
     @api.multi

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -898,7 +898,7 @@ class LogisticsRequisitionSource(models.Model):
         :returns: list of error strings
 
         """
-        return self._is_sourced_procurement()
+        return self._check_sourcing_procurement()
 
     @api.multi
     def _check_sourcing_wh_dispatch(self):

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -21,7 +21,7 @@
 import logging
 
 from openerp import models, fields, api
-from openerp.exceptions import except_orm
+from openerp.exceptions import except_orm, Warning
 from openerp.tools.translate import _
 import openerp.addons.decimal_precision as dp
 
@@ -495,10 +495,7 @@ class LogisticsRequisitionLine(models.Model):
         for source in self.source_ids:
             errors += source._check_sourcing()
         if errors:
-            raise except_orm(
-                _('Incorrect Sourcing'),
-                _('\n'.join(errors))
-            )
+            raise Warning(_('Incorrect Sourcing'), '\n'.join(errors))
         self.state = 'sourced'
 
     @api.one
@@ -887,10 +884,10 @@ class LogisticsRequisitionSource(models.Model):
 
         """
         if not self.po_requisition_id:
-            return ['Missing Purchase Requisition']
+            return ['{0}: Missing Purchase Requisition'.format(self.name)]
         if self.po_requisition_id.state not in ['done', 'closed']:
-            return ['Purchase Requisition state should be '
-                    '"Bids Selected" or "PO Created"']
+            return ['{0}: Purchase Requisition state should be '
+                    '"Bids Selected" or "PO Created"'.format(self.name)]
         return []
 
     @api.multi

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -491,12 +491,14 @@ class LogisticsRequisitionLine(models.Model):
 
     @api.one
     def _do_sourced(self):
+        errors = []
         for source in self.source_ids:
-            if not source._is_sourced():
-                raise except_orm(
-                    _('line %s is not sourced') % source.name,
-                    _('Please create source ressource using'
-                      ' various source line actions'))
+            errors += source._check_sourcing()
+        if errors:
+            raise except_orm(
+                _('Incorrect Sourcing'),
+                _('XXXXX')
+            )
         self.state = 'sourced'
 
     @api.one

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -20,8 +20,8 @@
 #
 import logging
 
-from openerp import models, fields, api
-from openerp.exceptions import except_orm, Warning
+from openerp import models, fields, api, exceptions
+from openerp.exceptions import except_orm
 from openerp.tools.translate import _
 import openerp.addons.decimal_precision as dp
 
@@ -493,11 +493,13 @@ class LogisticsRequisitionLine(models.Model):
     def _do_sourced(self):
         errors = []
         if not self.source_ids:
-            raise Warning(_('Incorrect Sourcing'), _('No Sourcing Lines'))
+            raise exceptions.Warning(_('Incorrect Sourcing'),
+                                     _('No Sourcing Lines'))
         for source in self.source_ids:
             errors += source._check_sourcing()
         if errors:
-            raise Warning(_('Incorrect Sourcing'), '\n'.join(errors))
+            raise exceptions.Warning(_('Incorrect Sourcing'),
+                                     '\n'.join(errors))
         self.state = 'sourced'
 
     @api.one

--- a/logistic_requisition/tests/__init__.py
+++ b/logistic_requisition/tests/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#    Author: Nicolas Bessi
+#    Author: Nicolas Bessi, Leonardo Pistone
 #    Copyright 2013-2014 Camptocamp SA
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -22,3 +22,4 @@ from . import test_purchase_split_requisition
 from . import test_sale_order_from_lr_confirm
 from . import test_mto_workflow
 from . import test_multicurrency_update_po_line
+from . import test_is_sourced

--- a/logistic_requisition/tests/__init__.py
+++ b/logistic_requisition/tests/__init__.py
@@ -23,3 +23,4 @@ from . import test_sale_order_from_lr_confirm
 from . import test_mto_workflow
 from . import test_multicurrency_update_po_line
 from . import test_check_sourcing
+from . import test_button_sourced

--- a/logistic_requisition/tests/__init__.py
+++ b/logistic_requisition/tests/__init__.py
@@ -22,4 +22,4 @@ from . import test_purchase_split_requisition
 from . import test_sale_order_from_lr_confirm
 from . import test_mto_workflow
 from . import test_multicurrency_update_po_line
-from . import test_is_sourced
+from . import test_check_sourcing

--- a/logistic_requisition/tests/test_button_sourced.py
+++ b/logistic_requisition/tests/test_button_sourced.py
@@ -33,6 +33,12 @@ class TestButtonSourced(TransactionCase):
         self.assertEqual("Incorrect Sourcing", cm.exception.args[0])
         self.assertIn("Missing Purchase Requisition", cm.exception.args[1])
 
+    def test_line_with_no_sourcing_fails(self):
+        with self.assertRaises(Warning) as cm:
+            self.lrl.button_sourced()
+        self.assertEqual("Incorrect Sourcing", cm.exception.args[0])
+        self.assertEqual("No Sourcing Lines", cm.exception.args[1])
+
     def setUp(self):
         """Setup a logistic requisition line.
 

--- a/logistic_requisition/tests/test_button_sourced.py
+++ b/logistic_requisition/tests/test_button_sourced.py
@@ -19,8 +19,9 @@ from openerp.exceptions import Warning
 
 class TestButtonSourced(TransactionCase):
     """Test that in a Logistic Requisition Line the Button sourced checks is
-    all the source lines are sourced correctly. All cases are tested
-    individually in TestCheckSourcing.
+    all the source lines are sourced correctly.
+
+    All cases are tested individually in TestCheckSourcing.
 
     """
     def test_line_with_procurement_sourcing_but_no_procurement_fails(self):
@@ -38,6 +39,13 @@ class TestButtonSourced(TransactionCase):
             self.lrl.button_sourced()
         self.assertEqual("Incorrect Sourcing", cm.exception.args[0])
         self.assertEqual("No Sourcing Lines", cm.exception.args[1])
+
+    def test_it_can_pass(self):
+        self.lrl.source_ids = self.LRS.new({
+            'procurement_method': 'wh_dispatch',
+        })
+        self.lrl.button_sourced()
+        self.assertEquals('sourced', self.lrl.state)
 
     def setUp(self):
         """Setup a logistic requisition line.

--- a/logistic_requisition/tests/test_button_sourced.py
+++ b/logistic_requisition/tests/test_button_sourced.py
@@ -1,0 +1,43 @@
+#    Author: Leonardo Pistone
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from openerp.tests.common import TransactionCase
+from openerp.exceptions import Warning
+
+
+class TestButtonSourced(TransactionCase):
+    """Test that in a Logistic Requisition Line the Button sourced checks is
+    all the source lines are sourced correctly. All cases are tested
+    individually in TestCheckSourcing.
+
+    """
+    def test_line_with_procurement_sourcing_but_no_procurement_fails(self):
+        self.lrl.source_ids = self.LRS.new({
+            'procurement_method': 'procurement',
+            'name': 'my source',
+        })
+        with self.assertRaises(Warning) as cm:
+            self.lrl.button_sourced()
+        self.assertEqual("Incorrect Sourcing", cm.exception.args[0])
+        self.assertIn("Missing Purchase Requisition", cm.exception.args[1])
+
+    def setUp(self):
+        """Setup a logistic requisition line.
+
+        """
+        super(TestButtonSourced, self).setUp()
+        LRL = self.env['logistic.requisition.line']
+        self.LRS = self.env['logistic.requisition.source']
+        self.lrl = LRL.new()

--- a/logistic_requisition/tests/test_button_sourced.py
+++ b/logistic_requisition/tests/test_button_sourced.py
@@ -14,7 +14,7 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from openerp.tests.common import TransactionCase
-from openerp.exceptions import Warning
+from openerp import exceptions
 
 
 class TestButtonSourced(TransactionCase):
@@ -29,13 +29,13 @@ class TestButtonSourced(TransactionCase):
             'procurement_method': 'procurement',
             'name': 'my source',
         })
-        with self.assertRaises(Warning) as cm:
+        with self.assertRaises(exceptions.Warning) as cm:
             self.lrl.button_sourced()
         self.assertEqual("Incorrect Sourcing", cm.exception.args[0])
         self.assertIn("Missing Purchase Requisition", cm.exception.args[1])
 
     def test_line_with_no_sourcing_fails(self):
-        with self.assertRaises(Warning) as cm:
+        with self.assertRaises(exceptions.Warning) as cm:
             self.lrl.button_sourced()
         self.assertEqual("Incorrect Sourcing", cm.exception.args[0])
         self.assertEqual("No Sourcing Lines", cm.exception.args[1])

--- a/logistic_requisition/tests/test_check_sourcing.py
+++ b/logistic_requisition/tests/test_check_sourcing.py
@@ -16,7 +16,7 @@
 from openerp.tests.common import TransactionCase
 
 
-class TestIsSourced(TransactionCase):
+class TestCheckSourcing(TransactionCase):
 
     def test_warehouse_dispatch_is_always_sourced(self):
         self.source.procurement_method = 'wh_dispatch'
@@ -58,7 +58,7 @@ class TestIsSourced(TransactionCase):
         database, but has working methods.
 
         """
-        super(TestIsSourced, self).setUp()
+        super(TestCheckSourcing, self).setUp()
         Source = self.env['logistic.requisition.source']
         self.PurcReq = self.env['purchase.requisition']
         self.source = Source.new()

--- a/logistic_requisition/tests/test_check_sourcing.py
+++ b/logistic_requisition/tests/test_check_sourcing.py
@@ -17,7 +17,11 @@ from openerp.tests.common import TransactionCase
 
 
 class TestCheckSourcing(TransactionCase):
+    """Check the _check_sourcing method of the source.
 
+    The button to check all sources of a line is checked in TestButtonSourced.
+
+    """
     def test_warehouse_dispatch_is_always_sourced(self):
         self.source.procurement_method = 'wh_dispatch'
         self.assertEquals([], self.source._check_sourcing())

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -22,7 +22,7 @@ class TestIsSourced(TransactionCase):
 
     def test_warehouse_dispatch_is_always_sourced(self):
         self.source.procurement_method = 'wh_dispatch'
-        self.assertTrue(self.source._is_sourced)
+        self.assertIs(True, self.source._is_sourced())
 
     def setUp(self):
         super(TestIsSourced, self).setUp()

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -1,0 +1,48 @@
+#    Author: Leonardo Pistone
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import time
+from openerp.tests.common import TransactionCase
+from openerp.tools import DEFAULT_SERVER_DATE_FORMAT as D_FMT
+
+
+class TestIsSourced(TransactionCase):
+
+    def test_warehouse_dispatch_is_always_sourced(self):
+        self.source.procurement_method = 'wh_dispatch'
+        self.assertTrue(self.source._is_sourced)
+
+    def setUp(self):
+        super(TestIsSourced, self).setUp()
+        LR = self.env['logistic.requisition']
+        LRL = self.env['logistic.requisition.line']
+        Source = self.env['logistic.requisition.source']
+        ModelData = self.env['ir.model.data']
+
+        lr = LR.create({
+            'pricelist_id': ModelData.xmlid_to_res_id('product.list0'),
+            'partner_id': ModelData.xmlid_to_res_id('base.res_partner_1'),
+            'date_delivery': time.strftime(D_FMT),
+        })
+        lrl = LRL.create({
+            'description': '/',
+            'requisition_id': lr.id,
+            'requested_uom_id': ModelData.xmlid_to_res_id(
+                'product.product_uom_unit'),
+            'date_delivery': time.strftime(D_FMT),
+        })
+        self.source = Source.create({
+            'requisition_line_id': lrl.id,
+        })

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -26,12 +26,14 @@ class TestIsSourced(TransactionCase):
 
     def test_procurement_sourcing_without_pr_is_not_sourced(self):
         self.source.procurement_method = 'procurement'
-        self.assertNotEquals([], self.source._check_sourcing())
+        errors = self.source._check_sourcing()
+        self.assertEquals(1, len(errors))
 
     def test_procurement_sourcing_with_draft_pr_is_not_sourced(self):
         self.source.procurement_method = 'procurement'
         self.source.po_requisition_id = self.purchase_req
-        self.assertNotEquals([], self.source._check_sourcing())
+        errors = self.source._check_sourcing()
+        self.assertEquals(1, len(errors))
 
     def test_procurement_sourcing_with_closed_pr_is_sourced(self):
         self.source.procurement_method = 'procurement'

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -22,28 +22,28 @@ class TestIsSourced(TransactionCase):
 
     def test_warehouse_dispatch_is_always_sourced(self):
         self.source.procurement_method = 'wh_dispatch'
-        self.assertIs(True, self.source._is_sourced())
+        self.assertEquals([], self.source._check_sourcing())
 
     def test_procurement_sourcing_without_pr_is_not_sourced(self):
         self.source.procurement_method = 'procurement'
-        self.assertIs(False, self.source._is_sourced())
+        self.assertNotEquals([], self.source._check_sourcing())
 
     def test_procurement_sourcing_with_draft_pr_is_not_sourced(self):
         self.source.procurement_method = 'procurement'
         self.source.po_requisition_id = self.purchase_req
-        self.assertIs(False, self.source._is_sourced())
+        self.assertNotEquals([], self.source._check_sourcing())
 
     def test_procurement_sourcing_with_closed_pr_is_sourced(self):
         self.source.procurement_method = 'procurement'
         self.purchase_req.state = 'closed'
         self.source.po_requisition_id = self.purchase_req
-        self.assertIs(True, self.source._is_sourced())
+        self.assertEquals([], self.source._check_sourcing())
 
     def test_procurement_sourcing_with_done_pr_is_sourced(self):
         self.source.procurement_method = 'procurement'
         self.purchase_req.state = 'done'
         self.source.po_requisition_id = self.purchase_req
-        self.assertIs(True, self.source._is_sourced())
+        self.assertEquals([], self.source._check_sourcing())
 
     def setUp(self):
         """Setup a source.

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -49,6 +49,12 @@ class TestIsSourced(TransactionCase):
         self.source.po_requisition_id = self.purchase_req
         self.assertEquals([], self.source._check_sourcing())
 
+    def test_other_sourcing_without_pr_is_not_sourced(self):
+        self.source.procurement_method = 'other'
+        errors = self.source._check_sourcing()
+        self.assertEquals(1, len(errors))
+        self.assertIn('Missing Purchase Requisition', errors[0])
+
     def setUp(self):
         """Setup a source.
 

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -39,6 +39,12 @@ class TestIsSourced(TransactionCase):
         self.source.po_requisition_id = self.purchase_req
         self.assertIs(True, self.source._is_sourced())
 
+    def test_procurement_sourcing_with_done_pr_is_sourced(self):
+        self.source.procurement_method = 'procurement'
+        self.purchase_req.state = 'done'
+        self.source.po_requisition_id = self.purchase_req
+        self.assertIs(True, self.source._is_sourced())
+
     def setUp(self):
         """Setup a source.
 

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -28,6 +28,11 @@ class TestIsSourced(TransactionCase):
         self.source.procurement_method = 'procurement'
         self.assertIs(False, self.source._is_sourced())
 
+    def test_procurement_sourcing_with_draft_pr_is_not_sourced(self):
+        self.source.procurement_method = 'procurement'
+        self.source.po_requisition_id = self.purchase_req
+        self.assertIs(False, self.source._is_sourced())
+
     def setUp(self):
         """Setup a source.
 
@@ -59,3 +64,7 @@ class TestIsSourced(TransactionCase):
         self.source = Source.create({
             'requisition_line_id': lrl.id,
         })
+        self.purchase_req = self.env['purchase.requisition'].search([(
+            'state', '=', 'draft'
+        )])
+        assert self.purchase_req

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -28,12 +28,14 @@ class TestIsSourced(TransactionCase):
         self.source.procurement_method = 'procurement'
         errors = self.source._check_sourcing()
         self.assertEquals(1, len(errors))
+        self.assertIn('Missing Purchase Requisition', errors[0])
 
     def test_procurement_sourcing_with_draft_pr_is_not_sourced(self):
         self.source.procurement_method = 'procurement'
         self.source.po_requisition_id = self.purchase_req
         errors = self.source._check_sourcing()
         self.assertEquals(1, len(errors))
+        self.assertIn('Purchase Requisition state should', errors[0])
 
     def test_procurement_sourcing_with_closed_pr_is_sourced(self):
         self.source.procurement_method = 'procurement'

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -33,6 +33,12 @@ class TestIsSourced(TransactionCase):
         self.source.po_requisition_id = self.purchase_req
         self.assertIs(False, self.source._is_sourced())
 
+    def test_procurement_sourcing_with_closed_pr_is_sourced(self):
+        self.source.procurement_method = 'procurement'
+        self.purchase_req.state = 'closed'
+        self.source.po_requisition_id = self.purchase_req
+        self.assertIs(True, self.source._is_sourced())
+
     def setUp(self):
         """Setup a source.
 

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -13,9 +13,7 @@
 #
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import time
 from openerp.tests.common import TransactionCase
-from openerp.tools import DEFAULT_SERVER_DATE_FORMAT as D_FMT
 
 
 class TestIsSourced(TransactionCase):

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -25,6 +25,15 @@ class TestIsSourced(TransactionCase):
         self.assertIs(True, self.source._is_sourced())
 
     def setUp(self):
+        """Setup a source.
+
+        Almost everything here except self.source is created only because of
+        required fields.
+
+        The tests should make sense also if we get rid of all that setUp and
+        replace self.source with some sort of mock or NewId.
+
+        """
         super(TestIsSourced, self).setUp()
         LR = self.env['logistic.requisition']
         LRL = self.env['logistic.requisition.line']

--- a/logistic_requisition/tests/test_is_sourced.py
+++ b/logistic_requisition/tests/test_is_sourced.py
@@ -24,6 +24,10 @@ class TestIsSourced(TransactionCase):
         self.source.procurement_method = 'wh_dispatch'
         self.assertIs(True, self.source._is_sourced())
 
+    def test_procurement_sourcing_without_pr_is_not_sourced(self):
+        self.source.procurement_method = 'procurement'
+        self.assertIs(False, self.source._is_sourced())
+
     def setUp(self):
         """Setup a source.
 


### PR DESCRIPTION
Having specific error messages stating the reason for the sourcing error required a refactoring of the various `_is_sourced` methods. Those seems to be untested, so I added some new tests for them.

I will then refactor the methods to return a string with the error message, or maybe raise an exception. 
