### PR TITLE
Revert "update travis config"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ python:
   - "2.7"
 
 env:
-  - VERSION="8.0" ODOO_REPO="OCA/OCB"   UNIT_TEST=1
-  - VERSION="8.0" ODOO_REPO="OCA/OCB"   EXCLUDE=logistic_consignee
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" UNIT_TEST=1
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" EXCLUDE=logistic_consignee
+  - VERSION="8.0" ODOO_REPO="odoo/odoo" EXCLUDE="logistic_consignee"
+  - VERSION="8.0" ODOO_REPO="OCA/OCB" EXCLUDE="logistic_consignee"
+  - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="logistic_consignee"
+  - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="logistic_consignee"
 
 virtualenv:
   system_site_packages: true


### PR DESCRIPTION
Reverts OCA/vertical-ngo#16

Builds seem to take too long and fill the queue (is it by project, probably). on the last builds in vertical-ngo the isolated builds take 30 minutes each.

I agreed in principle on checking the modules separately, but that does not seem to work well.
