### PR TITLE
Add domain on location in LRS: must be of type internal

### DIFF
--- a/logistic_requisition/view/logistic_requisition.xml
+++ b/logistic_requisition/view/logistic_requisition.xml
@@ -659,7 +659,7 @@
                             attrs="{'invisible': [('procurement_method', '!=', 'wh_dispatch')]}">
                             <field name="dispatch_location_id"
                                 attrs="{'required': [('procurement_method', '=', 'wh_dispatch')]}"
-                                domain="[('usage', '!=', 'view')]"/>
+                                domain="[('usage', '=', 'internal')]"/>
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
Hi,

We want a domain on internal location because it's a non-sense to look for "customer" location or "supplier" or "view". Dispatch is "by definition" from internal location.

Regards
