### PR TITLE
Fix Change assignee wizard to make it multi line

### DIFF
--- a/logistic_requisition/wizard/assign_line.py
+++ b/logistic_requisition/wizard/assign_line.py
@@ -33,10 +33,9 @@ class LogisticsRequisitionLineAssign(models.TransientModel):
 
     @api.multi
     def assign(self):
-        self.ensure_one()
         line_ids = self.env.context.get('active_ids')
         if not line_ids:
             return
         lines = self.env['logistic.requisition.line'].browse(line_ids)
-        lines.logistic_user_id = self.logistic_user_id.id
+        lines.write({'logistic_user_id': self.logistic_user_id.id})
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
Allow to select multiple Logistics Requisition Lines and use the wizard to change all assignee at once
