### PR TITLE
fix bug on sourced percentage, add test

### DIFF
--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -18,6 +18,8 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
+from __future__ import division
+
 import logging
 
 from openerp import models, fields, api, exceptions
@@ -180,9 +182,9 @@ class LogisticsRequisition(models.Model):
     @api.multi
     def _get_sourced(self):
         for requisition in self:
-            lines_len = sum(1.0 for req in requisition.line_ids
+            lines_len = sum(1 for req in requisition.line_ids
                             if req.state != 'cancel')
-            sourced_len = sum(1.0 for req in requisition.line_ids
+            sourced_len = sum(1 for req in requisition.line_ids
                               if req.state in ('sourced', 'quoted'))
             if lines_len == 0:
                 percentage = 0.

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -180,9 +180,9 @@ class LogisticsRequisition(models.Model):
     @api.multi
     def _get_sourced(self):
         for requisition in self:
-            lines_len = sum(1 for req in requisition.line_ids
+            lines_len = sum(1.0 for req in requisition.line_ids
                             if req.state != 'cancel')
-            sourced_len = sum(1 for req in requisition.line_ids
+            sourced_len = sum(1.0 for req in requisition.line_ids
                               if req.state in ('sourced', 'quoted'))
             if lines_len == 0:
                 percentage = 0.

--- a/logistic_requisition/tests/__init__.py
+++ b/logistic_requisition/tests/__init__.py
@@ -24,3 +24,4 @@ from . import test_mto_workflow
 from . import test_multicurrency_update_po_line
 from . import test_check_sourcing
 from . import test_button_sourced
+from . import test_sourcing_percentage

--- a/logistic_requisition/tests/test_sourcing_percentage.py
+++ b/logistic_requisition/tests/test_sourcing_percentage.py
@@ -1,0 +1,32 @@
+#    Author: Leonardo Pistone
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from openerp.tests.common import TransactionCase
+
+
+class TestSourcingPercentage(TransactionCase):
+    def test_one_sourced_out_of_two_is_50_percent(self):
+        self.lr = self.LR.new({
+            'line_ids': self.LRL.new({'state': 'draft'}) |
+                        self.LRL.new({'state': 'sourced'})
+        })
+        # "or 0.0" because odoo returns False instead of 0.0.
+        # I need float for assertAlmostEqual to give a good failure.
+        self.assertAlmostEqual(0.5, self.lr._get_sourced() or 0.0)
+
+    def setUp(self):
+        super(TestSourcingPercentage, self).setUp()
+        self.LR = self.env['logistic.requisition']
+        self.LRL = self.env['logistic.requisition.line']

--- a/logistic_requisition/tests/test_sourcing_percentage.py
+++ b/logistic_requisition/tests/test_sourcing_percentage.py
@@ -19,8 +19,10 @@ from openerp.tests.common import TransactionCase
 class TestSourcingPercentage(TransactionCase):
     def test_one_sourced_out_of_two_is_50_percent(self):
         self.lr = self.LR.new({
-            'line_ids': self.LRL.new({'state': 'draft'}) |
-                        self.LRL.new({'state': 'sourced'})
+            'line_ids': (
+                self.LRL.new({'state': 'draft'}) |
+                self.LRL.new({'state': 'sourced'})
+            )
         })
         # "or 0.0" because odoo returns False instead of 0.0.
         # I need float for assertAlmostEqual to give a good failure.


### PR DESCRIPTION
Because of a integer division error, with one sourced line out of two,
the sourcing percentage was zero instead of 0.5. Added a test to check
this case.
