### PR TITLE
Change workflow for agreement sourcing. PO can be created later

### DIFF
--- a/framework_agreement_sourcing/__openerp__.py
+++ b/framework_agreement_sourcing/__openerp__.py
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 {'name': 'Framework agreement integration in sourcing',
- 'version': '1.1',
+ 'version': '1.2',
  'author': 'Camptocamp',
  'maintainer': 'Camptocamp',
  'category': 'NGO',

--- a/framework_agreement_sourcing/view/requisition_view.xml
+++ b/framework_agreement_sourcing/view/requisition_view.xml
@@ -9,7 +9,7 @@
         <xpath expr="//header/group" position="after">
           <group attrs="{'invisible': [('procurement_method', '!=', 'fw_agreement')]}">
             <button name="%(action_view_create_agr_po_from_source)d"
-              states="assigned"
+              states="assigned,sourced"
               string="Create Agreement Purchase Order"
               class="oe_highlight"
               type="action"/>
@@ -49,7 +49,7 @@
                         string="Create Call for Bids"
                         type="object" position="after">
               <button name="%(action_view_create_agr_po_from_source)d"
-                        states="assigned"
+                        states="assigned,sourced"
                         string="Create Agreement Purchase Order"
                         type="action"/>
             </button>


### PR DESCRIPTION
Here we change the workflow for sourcing framework agreement to be closer to workflow of sourcing with purchase requisition.

It allows to set requisition line as sourced before creating purchase order from purchase requisition.
Checks have been added to ensure sourcing has a valid selected framework agreement.
