### PR TITLE
don't bring back onchange of picking type

### DIFF
--- a/ngo_purchase/view/purchase_order.xml
+++ b/ngo_purchase/view/purchase_order.xml
@@ -102,7 +102,7 @@
               <page string="Transportation and Delivery">
                 <group>
                   <group>
-                    <field name="picking_type_id" on_change="onchange_picking_type_id(picking_type_id, context)" domain="[('code','=','incoming')]" widget="selection" context="{'special_shortened_wh_name': True}" groups="stock.group_locations"/>
+                    <field name="picking_type_id" on_change="1" domain="[('code','=','incoming')]" widget="selection" context="{'special_shortened_wh_name': True}" groups="stock.group_locations"/>
                     <field name="location_id" groups="stock.group_locations"/>
                     <field name="related_location_id" invisible="1"/>
                     <!-- attrs and required domain removed by purchase_delivery_address -->
@@ -320,7 +320,7 @@
         </xpath>
 
         <field name="picking_type_id" position="attributes">
-          <attribute name="on_change">onchange_picking_type_id(picking_type_id)</attribute>
+          <attribute name="on_change">1</attribute>
         </field>
 
         <button name="action_cancel" position="attributes">

--- a/ngo_purchase/view/purchase_order.xml
+++ b/ngo_purchase/view/purchase_order.xml
@@ -107,7 +107,10 @@
                     <field name="related_location_id" invisible="1"/>
                     <!-- attrs and required domain removed by purchase_delivery_address -->
                     <!-- workaround odoo/odoo#2950 -->
-                    <field name="dest_address_id" on_change="onchange_dest_address_id(dest_address_id, context)"
+                    <field
+                      name="dest_address_id"
+                      on_change="1"
+                      string="Delivery Address"
                       groups="stock.group_locations"/>
                     <field name="origin_address_id"/>
                   </group>

--- a/ngo_purchase_requisition/view/purchase_requisition.xml
+++ b/ngo_purchase_requisition/view/purchase_requisition.xml
@@ -127,7 +127,14 @@
                 <group>
                   <group>
                     <field name="dest_address_id" attrs="{'readonly': [('state','!=','draft')]}"/>
-                    <field name="picking_type_id" widget="selection" groups="stock.group_locations" attrs="{'readonly': [('state','!=','draft')]}"/>
+                    <field
+                      name="picking_type_id"
+                      string="Deliver To"
+                      domain="[('code','=','incoming')]"
+                      context="{'special_shortened_wh_name': True}"
+                      widget="selection"
+                      groups="stock.group_locations"
+                      attrs="{'readonly': [('state','!=','draft')]}"/>
                   </group>
                   <group>
                     <field name="req_incoterm_id" attrs="{'readonly': [('state','!=','draft')]}"/>


### PR DESCRIPTION
This is due to purchase-workflow#66 that
converts that onchnage to new API (this in turn was to be consistent
with purchase_delivery_address where this onchange was first defined).

This fixes an incompatibility with purchase-workflow#66 that gives a
crash when changing the picking type on a purchase order.
