### PR TITLE
Fix budget on cost estimate creation with multiple Sources

### DIFF
--- a/logistic_budget/wizard/cost_estimate.py
+++ b/logistic_budget/wizard/cost_estimate.py
@@ -45,5 +45,10 @@ class LogisticRequisitionCostEstimate(models.TransientModel):
             LogisticRequisitionCostEstimate,
             self
         )._prepare_cost_estimate_line(source)
-        vals['budget_tot_price'] = source.requisition_line_id.budget_tot_price
+        req_line = source.requisition_line_id
+        if req_line.requested_qty:
+            # Compute the part of budget it consumes on pro-rata
+            budget_portion = source.proposed_qty / req_line.requested_qty
+            budget_tot_price = budget_portion * req_line.budget_tot_price
+            vals['budget_tot_price'] = budget_tot_price
         return vals


### PR DESCRIPTION
Divid Logistics requisition line budget by pro-rata of proposed product
of logistics requisition source.

Eg. 1 LRL budgetized at 1000.- is source by 1 LRS with 4 products
and 1 LRS with 6 products
Resulting Cost Estimate will have a line of 4 products with 400.-
budget and a second with 6 products with 600.- budget.
