### PR TITLE
fix: restore onchange on tender line form

### DIFF
--- a/ngo_purchase_requisition/view/purchase_requisition.xml
+++ b/ngo_purchase_requisition/view/purchase_requisition.xml
@@ -73,7 +73,7 @@
                   <form string="Products">
                     <group>
                       <group>
-                        <field name="product_id" />
+                        <field name="product_id" on_change="onchange_product_id(product_id,product_uom_id,parent.account_analytic_id,account_analytic_id,parent.schedule_date,schedule_date)"/>
                         <field name="account_analytic_id" groups="purchase.group_analytic_accounting"/>
                       </group>
                       <group>


### PR DESCRIPTION
This gives to the product field the same onchange we have in the tree
view.

One side effect of this is that by default this sets the quantity to 1
(instead of zero). Lines with quantity zero are easily overseen and give
problems later when bids cannot be selected because of differing
quantities.
