### PR TITLE
[FIX] Fix bug when try to open Call for bids for a logistic requision line

### DIFF
--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -733,7 +733,7 @@ class LogisticsRequisitionLine(models.Model):
         """
         purch_req = self._do_create_po_requisition()
         source_model = self.env['logistic.requisition.source']
-        return source_model.action_open_po_requisition(purch_req)
+        return source_model.open_po_requisition(purch_req)
 
     @api.model
     def _open_cost_estimate(self):
@@ -1146,10 +1146,10 @@ class LogisticsRequisitionSource(models.Model):
         Then open the created purchase requisition
         """
         purch_req = self._action_create_po_requisition()
-        return self.action_open_po_requisition(purch_req)
+        return self.open_po_requisition(purch_req)
 
     @api.multi
-    def action_open_po_requisition(self, purch_req=None):
+    def open_po_requisition(self, purch_req=None):
         if not purch_req:
             purch_req = self.po_requisition_id
         return {
@@ -1164,9 +1164,9 @@ class LogisticsRequisitionSource(models.Model):
         }
 
     @api.multi
-    def action_open_po_requisition_from_view(self):
+    def action_open_po_requisition(self):
         """Method called from view"""
-        return self.action_open_po_requisition()
+        return self.open_po_requisition()
 
     @api.multi
     @api.depends('unit_cost', 'proposed_qty')

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -1150,7 +1150,7 @@ class LogisticsRequisitionSource(models.Model):
 
     @api.multi
     def action_open_po_requisition(self, purch_req=None):
-        if not purch_req:
+        if not purch_req or not isinstance(purch_req, int):
             purch_req = self.po_requisition_id
         return {
             'type': 'ir.actions.act_window',

--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -1150,7 +1150,7 @@ class LogisticsRequisitionSource(models.Model):
 
     @api.multi
     def action_open_po_requisition(self, purch_req=None):
-        if not purch_req or not isinstance(purch_req, int):
+        if not purch_req:
             purch_req = self.po_requisition_id
         return {
             'type': 'ir.actions.act_window',
@@ -1162,6 +1162,11 @@ class LogisticsRequisitionSource(models.Model):
             'target': 'current',
             'nodestroy': True,
         }
+
+    @api.multi
+    def action_open_po_requisition_from_view(self):
+        """Method called from view"""
+        return self.action_open_po_requisition()
 
     @api.multi
     @api.depends('unit_cost', 'proposed_qty')

--- a/logistic_requisition/view/logistic_requisition.xml
+++ b/logistic_requisition/view/logistic_requisition.xml
@@ -448,7 +448,7 @@
                                         <field name="unit_cost"/>
                                         <field name="total_cost" sum="Total Budget"/>
                                         <field name="po_requisition_id" invisible="1"/>
-                                        <button name="action_open_po_requisition_from_view" icon="terp-stock_zoom"
+                                        <button name="action_open_po_requisition" icon="terp-stock_zoom"
                                             string="Purchase Requisition" type="object"
                                             attrs="{'invisible': [('po_requisition_id', '=', False)]}" />
                                     </tree>

--- a/logistic_requisition/view/logistic_requisition.xml
+++ b/logistic_requisition/view/logistic_requisition.xml
@@ -448,7 +448,7 @@
                                         <field name="unit_cost"/>
                                         <field name="total_cost" sum="Total Budget"/>
                                         <field name="po_requisition_id" invisible="1"/>
-                                        <button name="action_open_po_requisition" icon="terp-stock_zoom"
+                                        <button name="action_open_po_requisition_from_view" icon="terp-stock_zoom"
                                             string="Purchase Requisition" type="object"
                                             attrs="{'invisible': [('po_requisition_id', '=', False)]}" />
                                     </tree>


### PR DESCRIPTION
When a requisition line has a call for bids attached, if I click on the magnifying glass, I've a traceback saying me : ”AttributeError: 'dict' object has no attribute 'id'“
