### PR TITLE
framework_agreement_sourcing: fix crash

### DIFF
--- a/framework_agreement_sourcing/model/sale_order.py
+++ b/framework_agreement_sourcing/model/sale_order.py
@@ -58,7 +58,8 @@ class sale_order_line(orm.Model):
         sources = []
 
         for lrl in LRL.browse(cr, uid, lrl_ids, context=context):
-            sources.append(lrl.source_ids)
+            for lrs in lrl.source_ids:
+                sources.append(lrs)
 
         source_ids = [source.id for source in sources if source_valid(source)]
 


### PR DESCRIPTION
the sale_order confirmation button would crash in case multiple sourcing line for a given
sale_order_line were present (expected singleton)
