### PR TITLE
compute tender picking type on creation from LR

### DIFF
--- a/logistic_requisition/model/logistic_requisition.py
+++ b/logistic_requisition/model/logistic_requisition.py
@@ -1165,6 +1165,7 @@ class LogisticsRequisitionSource(models.Model):
         vals = self._prepare_po_requisition(purch_req_lines,
                                             pricelist=pricelist)
         purch_req = purch_req_obj.create(vals)
+        purch_req.onchange_dest_address_id()  # set the correct picking type
         self.write({'po_requisition_id': purch_req.id})
         return purch_req
 


### PR DESCRIPTION
The logic implemented in the onchange is correct. This uses it also when
a tender is created from a logistic requisition.
