### PR TITLE
make new field consignee required

### DIFF
--- a/logistic_consignee/model/sale_order.py
+++ b/logistic_consignee/model/sale_order.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
 #
-#    Author: Yannick Vaucher
-#    Copyright 2014 Camptocamp SA
+#    Author: Yannick Vaucher, Leonardo Pistone
+#    Copyright 2014-2015 Camptocamp SA
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -18,7 +18,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-from openerp import models, fields, api
+from openerp import models, fields
 from openerp import SUPERUSER_ID
 
 
@@ -41,15 +41,28 @@ class SaleOrder(models.Model):
         states=LO_STATES,
         help="The person to whom the shipment is to be delivered.")
 
-    @api.cr
-    def init(self, cr):
-        """set SUPERUSER_ID as consignee_id for existing sale orders
+    def _auto_init(self, cr, context):
+        """Fill in the required consignee column with default values.
+
+        This is similar to the solution used in mail_alias.py in the core.
+
+        The installation of the module will succeed with no errors, and the
+        column will be required immediately (the previous solution made it
+        required only on the first module update after installation).
+
         """
-        cr.execute('SELECT COUNT(id) FROM sale_order'
-                   ' WHERE consignee_id IS NULL')
-        count = cr.fetchone()[0]
-        if count:
-            cr.execute('UPDATE sale_order SET consignee_id=%s'
-                       ' WHERE consignee_id IS NULL', (SUPERUSER_ID,))
-            cr.execute('ALTER TABLE sale_order ALTER COLUMN consignee_id'
-                       ' SET NOT NULL')
+
+        # create the column non required
+        self._columns['consignee_id'].required = False
+        super(SaleOrder, self)._auto_init(cr, context=context)
+
+        # fill in the empty records
+        no_consignee_ids = self.search(cr, SUPERUSER_ID, [
+            ('consignee_id', '=', False)
+        ], context=context)
+        self.write(cr, SUPERUSER_ID, no_consignee_ids,
+                   {'consignee_id': SUPERUSER_ID}, context)
+
+        # make the column required again
+        self._columns['consignee_id'].required = True
+        super(SaleOrder, self)._auto_init(cr, context=context)

--- a/logistic_consignee/model/sale_order.py
+++ b/logistic_consignee/model/sale_order.py
@@ -19,7 +19,6 @@
 #
 #
 from openerp import models, fields
-from openerp import SUPERUSER_ID
 
 
 class SaleOrder(models.Model):
@@ -37,32 +36,5 @@ class SaleOrder(models.Model):
     consignee_id = fields.Many2one(
         'res.partner',
         string='Consignee',
-        required=True,
         states=LO_STATES,
         help="The person to whom the shipment is to be delivered.")
-
-    def _auto_init(self, cr, context):
-        """Fill in the required consignee column with default values.
-
-        This is similar to the solution used in mail_alias.py in the core.
-
-        The installation of the module will succeed with no errors, and the
-        column will be required immediately (the previous solution made it
-        required only on the first module update after installation).
-
-        """
-
-        # create the column non required
-        self._columns['consignee_id'].required = False
-        super(SaleOrder, self)._auto_init(cr, context=context)
-
-        # fill in the empty records
-        no_consignee_ids = self.search(cr, SUPERUSER_ID, [
-            ('consignee_id', '=', False)
-        ], context=context)
-        self.write(cr, SUPERUSER_ID, no_consignee_ids,
-                   {'consignee_id': SUPERUSER_ID}, context)
-
-        # make the column required again
-        self._columns['consignee_id'].required = True
-        super(SaleOrder, self)._auto_init(cr, context=context)

--- a/logistic_consignee/tests/__init__.py
+++ b/logistic_consignee/tests/__init__.py
@@ -21,8 +21,3 @@
 
 from . import test_consignee_purchase_order
 from . import test_consignee_sale_order
-
-checks = [
-    test_consignee_purchase_order,
-    test_consignee_sale_order,
-]

--- a/logistic_consignee/tests/test_consignee_purchase_order.py
+++ b/logistic_consignee/tests/test_consignee_purchase_order.py
@@ -66,6 +66,7 @@ class TestConsigneePurchaseOrder(common.TransactionCase):
 
         self.po.consignee_id = self.part1_id
         self.po.signal_workflow('purchase_confirm')
+        self.assertTrue(self.po.picking_ids)
         self.assertEquals(self.po.picking_ids.consignee_id,
                           self.po.consignee_id)
 

--- a/logistic_consignee/tests/test_consignee_sale_order.py
+++ b/logistic_consignee/tests/test_consignee_sale_order.py
@@ -47,6 +47,10 @@ class TestConsigneeSaleOrder(common.TransactionCase):
 
         self.so = SO.create(so_vals)
 
+        # sale exceptions, if installed, is irrelevant here. If it isn't this
+        # is no-op
+        self.so.ignore_exceptions = True
+
         sol_vals = {
             'order_id': self.so.id,
             'product_id': ref('product.product_product_33'),


### PR DESCRIPTION
The module logistic_consignee adds a required column, that gives
problems because a new column is initially empty on existing lines. The
previous solution filled in the values after installation, so we had the
problems:
- an error on module installation
- the field was not actually required, and became required only when the
  module was updated after installation.

This fixes both problems.
