### PR TITLE
ngo_purchase: fix cancel button visibility

### DIFF
--- a/ngo_purchase/view/purchase_order.xml
+++ b/ngo_purchase/view/purchase_order.xml
@@ -333,9 +333,8 @@
         </field>
 
         <button name="action_cancel" position="attributes">
-          <!-- approved,except_picking,except_invoice removed -->
           <!-- draftbid,draftpo added -->
-          <attribute name="states">draft,confirmed,sent,bid,draftbid,draftpo</attribute>
+          <attribute name="states">draft,confirmed,sent,bid,draftbid,draftpo,approved,except_picking,except_invoice</attribute>
         </button>
 
         <xpath expr="//button[@name='purchase_confirm']" position="after">


### PR DESCRIPTION
if we remove except_shipping then we have no way of canceling a PO
even if the supplier cannot send the goods. Same thing for except_invoice.
