### PR TITLE
Check for negative available quantities

### DIFF
--- a/framework_agreement_sourcing/model/logistic_requisition.py
+++ b/framework_agreement_sourcing/model/logistic_requisition.py
@@ -141,7 +141,7 @@ class logistic_requisition_line(orm.Model):
             return qty
         current_agr = agreements.pop(0)
         avail = current_agr.available_quantity
-        if not avail:
+        if avail <= 0:
             return qty
         avail_sold = avail - qty
         to_consume = qty if avail_sold >= 0 else avail


### PR DESCRIPTION
This (small) PR is to fix the rare case where available quantities on the framework agreement are negative; if not for it, the method will continue and create a sourcing line with negative quantity on the framework agreement, and another sourcing line with (-negative quantity + requested quantity) as a procurement.
