### PR TITLE
Don't copy source line ID when copying sale order line

### DIFF
--- a/logistic_requisition/model/sale_order.py
+++ b/logistic_requisition/model/sale_order.py
@@ -192,3 +192,12 @@ class sale_order_line(orm.Model):
         for purchase_requisition in purchase_requisitions:
             purchase_requisition.generate_po()
         return result
+
+    def copy_data(self, cr, uid, id, default=None, context=None):
+        if not default:
+            default = {}
+        default.update({
+            'logistic_requisition_source_id': False,
+        })
+        return super(sale_order_line, self).copy_data(
+            cr, uid, id, default=default, context=context)


### PR DESCRIPTION
PR to avoid copying the source line ID when copying a sale order line; this is to create a duplicate SO without calling back to the orignal SO's sourcing workflow.
