### PR TITLE
Fixes on Logistics Orders

### DIFF
--- a/logistic_budget/model/sale_order.py
+++ b/logistic_budget/model/sale_order.py
@@ -25,23 +25,29 @@ class SaleOrder(models.Model):
     budget_holder_id = fields.Many2one(
         'res.users',
         string='Budget Holder',
-        states=base_logistics_order.LO_STATES)
+        states=base_logistics_order.LO_STATES,
+        copy=False)
     date_budget_holder = fields.Datetime(
         'Budget Holder Validation Date',
-        states=base_logistics_order.LO_STATES)
+        states=base_logistics_order.LO_STATES,
+        copy=False)
     budget_holder_remark = fields.Text(
         'Budget Holder Remark',
-        states=base_logistics_order.LO_STATES)
+        states=base_logistics_order.LO_STATES,
+        copy=False)
     finance_officer_id = fields.Many2one(
         'res.users',
         string='Finance Officer',
-        states=base_logistics_order.LO_STATES)
+        states=base_logistics_order.LO_STATES,
+        copy=False)
     date_finance_officer = fields.Datetime(
         'Finance Officer Validation Date',
-        states=base_logistics_order.LO_STATES)
+        states=base_logistics_order.LO_STATES,
+        copy=False)
     finance_officer_remark = fields.Text(
         'Finance Officer Remark',
-        states=base_logistics_order.LO_STATES)
+        states=base_logistics_order.LO_STATES,
+        copy=False)
     total_budget = fields.Float("Total Budget", compute='_total_budget',
                                 store=True)
 
@@ -72,4 +78,4 @@ class SaleOrder(models.Model):
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    budget_tot_price = fields.Float("Budget Amount")
+    budget_tot_price = fields.Float("Budget Amount", copy=False)

--- a/logistic_order/view/sale_order_view.xml
+++ b/logistic_order/view/sale_order_view.xml
@@ -114,7 +114,9 @@
         <field name="currency_id" position="replace"/>
         <field name="project_id" position="replace"/>
         <field name="order_policy" position="replace"/>
-        <field name="carrier_id" position="replace"/>
+        <field name="carrier_id" position="attributes">
+          <attribute name="invisible" eval="1"/>
+        </field>
         <field name="incoterm" position="replace"/>
         <field name="payment_term" position="replace"/>
         <field name="fiscal_position" position="replace"/>
@@ -153,7 +155,6 @@
               </group>
               <group>
                 <field name="delivery_time"/>
-                <field name="carrier_id"/>
               </group>
             </group>
             <group string="Delivery Remarks">

--- a/logistic_order/view/sale_order_view.xml
+++ b/logistic_order/view/sale_order_view.xml
@@ -121,6 +121,21 @@
         <field name="company_id" position="replace"/>
         <field name="note" position="replace"/>
 
+        <!-- hide taxes -->
+        <xpath expr="//page[@string='Order Lines']/field[@name='order_line']/form//field[@name='tax_id']" position="attributes">
+          <attribute name="invisible" eval="1"/>
+        </xpath>
+        <xpath expr="//page[@string='Order Lines']/field[@name='order_line']/tree//field[@name='tax_id']" position="attributes">
+          <attribute name="invisible" eval="1"/>
+        </xpath>
+        <xpath expr="//page[@string='Order Lines']//field[@name='amount_untaxed']" position="attributes">
+          <attribute name="invisible" eval="1"/>
+        </xpath>
+        <xpath expr="//page[@string='Order Lines']//field[@name='amount_tax']" position="attributes">
+          <attribute name="invisible" eval="1"/>
+        </xpath>
+
+
         <!-- remove field delay -->
         <xpath expr="//page[@string='Order Lines']/field[@name='order_line']/form//label[@for='delay']" position="replace"/>
         <xpath expr="//page[@string='Order Lines']/field[@name='order_line']/form//field[@name='delay']/.." position="replace">

--- a/logistic_order/view/sale_order_view.xml
+++ b/logistic_order/view/sale_order_view.xml
@@ -121,6 +121,14 @@
         <field name="company_id" position="replace"/>
         <field name="note" position="replace"/>
 
+        <!-- remove field delay -->
+        <xpath expr="//page[@string='Order Lines']/field[@name='order_line']/form//label[@for='delay']" position="replace"/>
+        <xpath expr="//page[@string='Order Lines']/field[@name='order_line']/form//field[@name='delay']/.." position="replace">
+          <div>
+            <field name="delay" invisible="1"/>
+          </div>
+        </xpath>
+
         <xpath expr="//notebook/page[@string='Order Lines']" position="after">
           <page string="Transportation and Delivery">
             <group>

--- a/logistic_order/view/sale_order_view.xml
+++ b/logistic_order/view/sale_order_view.xml
@@ -123,6 +123,11 @@
         <field name="company_id" position="replace"/>
         <field name="note" position="replace"/>
 
+        <xpath expr="//page[@string='Order Lines']/field[@name='order_line']/form//field[@name='product_uos']" position="after">
+          <field name="volume"/>
+          <field name="weight"/>
+        </xpath>
+
         <!-- hide taxes -->
         <xpath expr="//page[@string='Order Lines']/field[@name='order_line']/form//field[@name='tax_id']" position="attributes">
           <attribute name="invisible" eval="1"/>
@@ -152,6 +157,8 @@
               <group>
                 <field name="incoterm"/>
                 <field name="incoterm_address"/>
+                <field name="volume"/>
+                <field name="weight"/>
               </group>
               <group>
                 <field name="delivery_time"/>


### PR DESCRIPTION
- Remove delay from sale order line popup form view
- On duplication of LO we don't want to copy budget validation values
- No need for taxes in NGO context
- Hide carrier on LO form
- display weight and volumes
