### PR TITLE
make currency always readonly in purchase order

### DIFF
--- a/ngo_purchase/view/purchase_order.xml
+++ b/ngo_purchase/view/purchase_order.xml
@@ -131,7 +131,7 @@
                 <group>
                   <group>
                     <field domain="[('type','=','purchase')]" name="pricelist_id" groups="product.group_purchase_pricelist" on_change="onchange_pricelist(pricelist_id, context)"/>
-                    <field name="currency_id" groups="base.group_multi_currency"/>
+                    <field name="currency_id" groups="base.group_multi_currency" readonly="True" />
                     <field name="company_id" groups="base.group_multi_company" widget="selection"/>
                     <field name="journal_id" invisible='1'/>
                   </group>


### PR DESCRIPTION
I am making this only in the NGO verticalisation because it makes sense
only if the user belongs to the group_purchase_pricelist. See

https://github.com/OCA/purchase-workflow/pull/88#issuecomment-98706482
