### PR TITLE
fix view on button "New Copy of Quotation"

### DIFF
--- a/logistic_order/model/sale_order.py
+++ b/logistic_order/model/sale_order.py
@@ -162,6 +162,23 @@ class SaleOrder(models.Model):
     def action_accepted(self):
         self.write({'state': 'accepted'})
 
+    @api.multi
+    def copy_quotation(self):
+        """Copy the quotation and open it in the current form view.
+
+        Do not specify the view, so that the inherited one is chosen."""
+        new_estimate = self.copy()
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _('Cost Estimate'),
+            'res_model': 'sale.order',
+            'res_id': new_estimate.id,
+            'view_type': 'form',
+            'view_mode': 'form',
+            'target': 'current',
+            'nodestroy': True,
+        }
+
 
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'


### PR DESCRIPTION
That is because the original in the sale module forces usage of the
original view. Here I do not specify the view, so that the correct
inherited one is taken.
