### PR TITLE
Set picking planned date to logistics order's logistics requisition e…

### DIFF
--- a/logistic_requisition/model/sale_order.py
+++ b/logistic_requisition/model/sale_order.py
@@ -187,6 +187,14 @@ class SaleOrder(models.Model):
 
         return action_dict
 
+    @api.model
+    def _get_date_planned(self, order, line, start_date):
+        if line.lr_source_id:
+            return line.lr_source_id.requisition_line_id.date_delivery
+        else:
+            return super(SaleOrder, self
+                         )._get_date_planned(order, line, start_date)
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"


### PR DESCRIPTION
…xpected date

This way moves created by the procurement in case of dropshipping
passing by Outgoing transit, will have a date matching with move going
from Outgoing transit to Custormer location. Otherwise, 1st move could
have a later date than in 2nd move. Which would mismatch when using
Shipment management with ETD and ETA.
